### PR TITLE
chore(deps): migrate to sqlite3 3.x + drift_flutter 0.3.0

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "5b7468c326d2f8a4f630056404ca0d291ade42918f4a3c6233618e724f39da8e"
+      sha256: "8d7ff3948166b8ec5da0fbb5962000926b8e02f2ed9b3e51d1738905fbd4c98d"
       url: "https://pub.dev"
     source: hosted
-    version: "92.0.0"
+    version: "93.0.0"
   analyzer:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: analyzer
-      sha256: "70e4b1ef8003c64793a9e268a551a82869a8a96f39deb73dea28084b0e8bf75e"
+      sha256: de7148ed2fcec579b19f122c1800933dfa028f6d9fd38a152b04b1516cec120b
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "10.0.1"
   analyzer_buffer:
     dependency: transitive
     description:
@@ -314,13 +314,13 @@ packages:
     source: hosted
     version: "3.0.7"
   dart_style:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: dart_style
-      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
+      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.1.7"
   dbus:
     dependency: transitive
     description:
@@ -357,26 +357,26 @@ packages:
     dependency: "direct main"
     description:
       name: drift
-      sha256: "970cd188fddb111b26ea6a9b07a62bf5c2432d74147b8122c67044ae3b97e99e"
+      sha256: "055c249d1f91be5a47fe447f88afc24c4ca6f4cd6c5ed66767b4797d48acc2e5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.31.0"
+    version: "2.32.1"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: "917184b2fb867b70a548a83bf0d36268423b38d39968c06cce4905683da49587"
+      sha256: "88a9de3af8571518148a6d8a513b57779fd1e60a026d3ab8a481a878fba01d91"
       url: "https://pub.dev"
     source: hosted
-    version: "2.31.0"
+    version: "2.32.1"
   drift_flutter:
     dependency: "direct main"
     description:
       name: drift_flutter
-      sha256: c07120854742a0cae2f7501a0da02493addde550db6641d284983c08762e60a7
+      sha256: "887fdec622174dc7eaefd0048403e34ee07cc18626ac8a7544cc3b8a4a172166"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.8"
+    version: "0.3.0"
   equatable:
     dependency: transitive
     description:
@@ -692,10 +692,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1241,30 +1241,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
+  sqlcipher_flutter_libs:
+    dependency: transitive
+    description:
+      name: sqlcipher_flutter_libs
+      sha256: "38d62d659d2fb8739bf25a42c9a350d1fdd6c29a5a61f13a946778ec75d27929"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0+eol"
   sqlite3:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2"
+      sha256: f8f8ba7f9454f2761d4b416e030c4528ebc45e9290798d848f4dc08890c42a7c
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.4"
+    version: "3.1.7"
   sqlite3_flutter_libs:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: sqlite3_flutter_libs
-      sha256: eeb9e3a45207649076b808f8a5a74d68770d0b7f26ccef6d5f43106eee5375ad
+      sha256: "3ed7553eee7bb368f8950f58ba29f634e06e813c029aff6a0d60862b96de8454"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.42"
+    version: "0.6.0+eol"
   sqlparser:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "337e9997f7141ffdd054259128553c348635fa318f7ca492f07a4ab76f850d19"
+      sha256: ab2b467425f1d4f3acfa5fd11a08226f7d6c26ff102c06be1807e1dff34e050b
       url: "https://pub.dev"
     source: hosted
-    version: "0.43.1"
+    version: "0.44.3"
   stack_trace:
     dependency: transitive
     description:
@@ -1333,26 +1341,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.29.0"
+    version: "1.30.0"
   test_api:
     dependency: "direct dev"
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.15"
+    version: "0.6.16"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,8 +17,8 @@ dependencies:
   connectivity_plus: ^7.0.0
   crypto: ^3.0.6
   dio: ^5.8.0+1
-  drift: ^2.23.1
-  drift_flutter: ^0.2.4
+  drift: ^2.32.1
+  drift_flutter: ^0.3.0
   flutter:
     sdk: flutter
   flutter_riverpod: ^3.2.1
@@ -35,7 +35,6 @@ dependencies:
   sentry_flutter: ^9.13.0
   shared_preferences: ^2.5.3
   shimmer: ^3.0.0
-  sqlite3_flutter_libs: ^0.5.30
   url_launcher: ^6.3.1
   uuid: ^4.5.1
   wakelock_plus: ^1.4.0
@@ -46,7 +45,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.14
-  drift_dev: ^2.23.1
+  drift_dev: ^2.32.1
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4
@@ -76,6 +75,15 @@ flutter:
 # See https://github.com/okadan/flutter-nfc-manager/issues/252
 # Remove when upstream merges PR #260 and releases.
 dependency_overrides:
+  # WORKAROUND: riverpod_generator 4.0.3 pins analyzer ^9.0.0 but the
+  # GitHub source already supports >=10.0.0 <13.0.0 (issue #4732).
+  # drift_dev 2.32.1 requires analyzer >=10.0.0. Remove when
+  # riverpod_generator publishes a new release.
+  analyzer: ^10.0.0
+  # WORKAROUND: dart_style 3.1.3 (transitive via build_runner) is
+  # incompatible with analyzer 10+. Pin 3.1.7 which supports
+  # >=10.0.0 <12.0.0. 3.1.8 requires analyzer ^12.0.0.
+  dart_style: 3.1.7
   nfc_manager:
     path: packages/nfc_manager
 


### PR DESCRIPTION
Migrates from the deprecated `sqlite3_flutter_libs` package to the new sqlite3 3.x hook-based binary bundling.

## Changes

- `drift`: ^2.23.1 → ^2.32.1
- `drift_dev`: ^2.23.1 → ^2.32.1  
- `drift_flutter`: ^0.2.4 → ^0.3.0
- `sqlite3_flutter_libs`: ^0.5.30 removed (deprecated, 0.6.0 is end-of-life / no-op)
- `sqlite3`: ^3.1.7 via drift_flutter transitive

## Why

`sqlite3_flutter_libs` 0.6.0 is deprecated and contains no code. sqlite3 3.x uses Dart hooks to download and bundle prebuilt SQLite binaries from GitHub releases, replacing the old Flutter plugin build script approach.

## Workarounds (dependency_overrides)

- `analyzer: ^10.0.0` — riverpod_generator 4.0.3 pins `analyzer ^9.0.0` but the GitHub source already supports `>=10.0.0 <13.0.0` (rrousselGit/riverpod#4732). The published version just hasn't been released yet.
- `dart_style: 3.1.7` — transitive via build_runner, incompatible with analyzer 10+. 3.1.8 requires analyzer ^12.0.0.

## Verified

- [x] `flutter pub get` resolves cleanly
- [x] `dart run build_runner build` generates 365 outputs
- [x] `dart format` passes
- [x] `flutter analyze --fatal-infos` passes
- [x] `flutter test` — all 423 tests pass
- [x] `flutter build apk --debug` compiles

Closes #257, closes #262.
